### PR TITLE
resolved an issue with scripts/ea's failing to upload if a non-existant category was specified

### DIFF
--- a/aiojss
+++ b/aiojss
@@ -1,1 +1,0 @@
-submodules/aiojss/aiojss

--- a/sync.py
+++ b/sync.py
@@ -190,7 +190,7 @@ async def upload_scripts(session, url, user, passwd, semaphore):
  
     if len(changed_scripts) == 0 and not args.update_all:
         print('No Changes in Scripts')
-        # return
+        return
 
     else:
         scripts = [f.name for f in os.scandir(join(mypath, 'scripts'))

--- a/sync.py
+++ b/sync.py
@@ -274,7 +274,7 @@ async def get_existing_categories(session, url, user, passwd, semaphore):
     auth = aiohttp.BasicAuth(user, passwd)
     headers = {'content-type': 'application/xml'}
     async with semaphore:
-        with async_timeout.timeout(10):
+        with async_timeout.timeout(args.timeout):
             async with session.get(url + '/JSSResource/categories',
                                    auth=auth) as resp:
                 if resp.status in (201, 200):

--- a/sync.py
+++ b/sync.py
@@ -17,6 +17,7 @@ slack_emoji = ":white_check_mark: "
 supported_script_extensions = ('sh', 'py', 'pl', 'swift', 'rb')
 supported_ea_extensions = ('sh', 'py', 'pl', 'swift', 'rb')
 supported_profile_extensions = ('.mobileconfig', '.profile')
+categories = []
 
 
 def check_for_changes():
@@ -157,6 +158,11 @@ async def get_ea_template(session, url, user, passwd, ext_attr):
     # name is mandatory, so we use the foldername if nothing is set in a template
     if args.verbose:
         print(ET.tostring(template))
+    if template.find('category') and template.find('category').text not in categories:
+        ET.SubElement(template, 'category').text = 'None'
+        if args.verbose:
+            c = template.find('category').text
+            print(f'WARNING: Unable to find category {c} in the JSS, setting to None')
     if template.find('name') is None:
         ET.SubElement(template, 'name').text = ext_attr
     elif template.find('name').text is '' or template.find('name').text is None:
@@ -169,7 +175,7 @@ async def upload_scripts(session, url, user, passwd, semaphore):
 
     if len(changed_scripts) == 0:
         print('No Changes in Scripts')
-        return
+        # return
 
     if args.update_all:
         scripts = [f.name for f in os.scandir(join(mypath, 'scripts'))
@@ -230,6 +236,11 @@ async def get_script_template(session, url, user, passwd, script):
     # name is mandatory, so we use the filename if nothing is set in a template
     if args.verbose:
         print(ET.tostring(template))
+    if template.find('category') is not None and template.find('category').text not in categories:
+        c = template.find('category').text
+        template.remove(template.find('category'))
+        if args.verbose:
+            print(f'WARNING: Unable to find category "{c}" in the JSS, setting to None')
     if template.find('name') is None:
         ET.SubElement(template, 'name').text = script
     elif template.find('name').text is '' or template.find('name').text is None:
@@ -237,10 +248,23 @@ async def get_script_template(session, url, user, passwd, script):
     return template
 
 
+async def get_existing_categories(session, url, user, passwd, semaphore):
+    auth = aiohttp.BasicAuth(user, passwd)
+    headers = {'content-type': 'application/xml'}
+    async with semaphore:
+        with async_timeout.timeout(10):
+            async with session.get(url + '/JSSResource/categories',
+                                   auth=auth) as resp:
+                if resp.status in (201, 200):
+                    return [c.find('name').text for c in [e for e in ET.fromstring(await resp.text()).findall('category')]]
+    return []
+
 async def main(args):
+    global categories
     semaphore = asyncio.BoundedSemaphore(args.limit)
     async with aiohttp.ClientSession() as session:
         async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(verify_ssl=args.do_not_verify_ssl)) as session:
+            categories = await get_existing_categories(session, args.url, args.username, args.password, semaphore)
             await upload_scripts(session, args.url, args.username, args.password, semaphore)
             await upload_extension_attributes(session, args.url, args.username, args.password, semaphore)
 


### PR DESCRIPTION
sync.py will now clear the category from the upload if it doesn't already exist in the jss
a warning will be issued if --verbose is turned on