### PR TITLE
Resolved issues with criteria matching the opposite value of intended

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -71,7 +71,7 @@ def write_jenkins_file():
         If there are no changes, the variable will be set to 'None'
     """
 
-    if changed_ext_attrs:
+    if not changed_ext_attrs:
         contents = "eas=" + "None"
     else:
         contents = "eas=" + SLACK_EMOJI + changed_ext_attrs[0] + '\\n' + '\\'
@@ -79,7 +79,7 @@ def write_jenkins_file():
             contents = contents + '\n' + SLACK_EMOJI + \
                        changed_ext_attr + '\\n' + '\\'
 
-    if changed_scripts:
+    if not changed_scripts:
         contents = contents.rstrip('\\') + '\n' + "scripts=" + "None"
 
     else:
@@ -96,7 +96,7 @@ def write_jenkins_file():
 
 async def upload_extension_attributes(session, url, user, passwd, semaphore):
     mypath = dirname(realpath(__file__))
-    if changed_ext_attrs and not args.update_all:
+    if not changed_ext_attrs and not args.update_all:
         print('No Changes in Extension Attributes')
         return
     ext_attrs = [
@@ -235,7 +235,7 @@ async def get_ea_template(session, url, user, passwd, ext_attr):
 async def upload_scripts(session, url, user, passwd, semaphore):
     mypath = dirname(realpath(__file__))
 
-    if changed_scripts and not args.update_all:
+    if not changed_scripts and not args.update_all:
         print('No Changes in Scripts')
     scripts = [
         f.name for f in os.scandir(join(mypath, 'scripts')) if f.is_dir()


### PR DESCRIPTION
In order to upload changes to EAs or Scripts, I had to change lines 99 and 238 as it was stating that if there were changes to print "No Changes" and ending the run.

In order to properly send Jenkins notifications, I also had to change lines 74 and 82 to properly send that if there were no changes to send "None". 

Please feel free to edit or ask clarifications about my environment because maybe it's just me, but I'm genuinely not sure how this has been working for other people as it seemed to be configured to do the exact opposite of what was expected. 